### PR TITLE
Train process crashes after TrialPruned exception

### DIFF
--- a/hparam_search.py
+++ b/hparam_search.py
@@ -217,6 +217,8 @@ def train(hparams, seed, trial, env_id):
                 except sqlalchemy.exc.OperationalError:
                     print(f"CAUGHT SQL CONNECTION ERROR DURING REPORT/PRUNE: \n"
                           f"Couldn't connect to RDB at frame {experiment._frame}")
+                except optuna.exceptions.TrialPruned:
+                    return mean_norm_return
                 except Exception as e:
                     mark_trial_stopped()
                     raise e
@@ -376,5 +378,5 @@ if __name__ == "__main__":
     for key, value in trial.params.items():
         print("    {}: {}".format(key, value))
 
-    with open(f"best_params_{args.env}.pkl", 'wb') as fd:
+    with open(f"best_params_{args.envs.replace(',', '_')}.pkl", 'wb') as fd:
         dill.dump(trial.params, fd)


### PR DESCRIPTION
Train process was crashing if a trial is pruned and not restarting the next trial with new hparams.
```python
[I 2022-05-16 07:42:38,136] Trial 72 pruned. ray::train() (pid=253737, ip=172.17.0.3)
  File "hparam_search.py", line 222, in train
    raise e
  File "hparam_search.py", line 216, in train
    raise optuna.exceptions.TrialPruned()
optuna.exceptions.TrialPruned
```
So I modified the error handling part in train function at hparam_search.py.
 
I Also changed the file name for dumping the best_params to a pickle. 
This was due to the following error.
```python
Traceback (most recent call last):
  File "hparam_search.py", line 379, in <module>
    with open(f"best_params_{args.env}.pkl", 'wb') as fd:
AttributeError: 'Namespace' object has no attribute 'env'
```